### PR TITLE
Update ParticleSystem.java

### DIFF
--- a/LeonidasLib/src/com/plattysoft/leonids/ParticleSystem.java
+++ b/LeonidasLib/src/com/plattysoft/leonids/ParticleSystem.java
@@ -78,6 +78,9 @@ public class ParticleSystem {
 		
 		mParentLocation = new int[2];		
 		mParentView.getLocationInWindow(mParentLocation);
+		
+		DisplayMetrics displayMetrics = a.getResources().getDisplayMetrics();
+		mDpToPxScale = (displayMetrics.xdpi / DisplayMetrics.DENSITY_DEFAULT);
 	}
 
 	/**
@@ -117,8 +120,6 @@ public class ParticleSystem {
 		else {
 			// Not supported, no particles are being created
 		}
-		DisplayMetrics displayMetrics = a.getResources().getDisplayMetrics();
-		mDpToPxScale = (displayMetrics.xdpi / DisplayMetrics.DENSITY_DEFAULT);
 	}
 
 	public float dpToPx(float dp) {


### PR DESCRIPTION
Fixed bug with some constructors not setting mDpToPxScale. This caused particles to not move (speed multiplied by zero). 

Note: Jar file will need to be updated.