### PR TITLE
Applying time for affecting particle attributes according to duration.

### DIFF
--- a/LeonidsExamples/src/main/java/com/plattysoft/leonids/examples/ConfettiExampleActivity.java
+++ b/LeonidsExamples/src/main/java/com/plattysoft/leonids/examples/ConfettiExampleActivity.java
@@ -17,12 +17,15 @@ public class ConfettiExampleActivity extends Activity implements OnClickListener
 	}
 
 	@Override
-	public void onClick(View arg0) {		
-		new ParticleSystem(this, 80, R.drawable.confeti2, 10000)
+	public void onClick(View arg0) {
+		ParticleSystem particleSystem = new ParticleSystem(this, 80, R.drawable.confeti2, 10000);
+		particleSystem
 		.setSpeedModuleAndAngleRange(0f, 0.1f, 180, 180)
 		.setRotationSpeed(144)
-		.setAcceleration(0.000017f, 90)		
+		.setAcceleration(0.000017f, 90)
 		.emit(findViewById(R.id.emiter_top_right), 8);
+
+		particleSystem.applyTime(15000);
 				
 		new ParticleSystem(this, 80, R.drawable.confeti3, 10000)
 		.setSpeedModuleAndAngleRange(0f, 0.1f, 0, 0)

--- a/LeonidsLib/src/main/java/com/plattysoft/leonids/ParticleSystem.java
+++ b/LeonidsLib/src/main/java/com/plattysoft/leonids/ParticleSystem.java
@@ -34,6 +34,7 @@ import android.view.animation.LinearInterpolator;
 
 public class ParticleSystem {
 
+	private static final long IDEAL_FRAME_DURATION = 17;
 	private static final long TIMMERTASK_INTERVAL = 50;
 	private ViewGroup mParentView;
 	private int mMaxParticles;
@@ -261,6 +262,11 @@ public class ParticleSystem {
 
 	public ParticleSystem setAcceleration(float acceleration, int angle) {
 		mInitializers.add(new AccelerationInitializer(acceleration, acceleration, angle, angle));
+		return this;
+	}
+
+	public ParticleSystem addInitializer(ParticleInitializer particleInitializer) {
+		mInitializers.add(particleInitializer);
 		return this;
 	}
 
@@ -599,6 +605,13 @@ public class ParticleSystem {
 		long frameTimeInMs = mCurrentTime / framesCount;
 		for (int i = 1; i <= framesCount; i++) {
 			onUpdate(frameTimeInMs * i + 1);
+		}
+	}
+
+	public void applyTime(long timeToApply) {
+		for(long delta = 0; delta <= timeToApply; delta+=IDEAL_FRAME_DURATION) {
+			mCurrentTime += IDEAL_FRAME_DURATION;
+			onUpdate(mCurrentTime);
 		}
 	}
 }


### PR DESCRIPTION
- setStartTime doesn't make the same effect with applyTime due to life times of particles.
- addInitializer method added for being able to add custom initializers.