### PR TITLE
Fix for particles in dialog fragment and javadoc.

### DIFF
--- a/LeonidsLib/src/main/java/com/plattysoft/leonids/ParticleSystem.java
+++ b/LeonidsLib/src/main/java/com/plattysoft/leonids/ParticleSystem.java
@@ -65,7 +65,10 @@ public class ParticleSystem {
 
 	private ParticleSystem(Activity a, int maxParticles, long timeToLive, int parentResId) {
 		mRandom = new Random();
-		mParentView = (ViewGroup) a.findViewById(parentResId);
+        mParentLocation = new int[2];
+
+        mParentView = (ViewGroup) a.findViewById(parentResId);
+		setParentViewGroup(mParentView);
 
 		mModifiers = new ArrayList<ParticleModifier>();
 		mInitializers = new ArrayList<ParticleInitializer>();
@@ -75,9 +78,6 @@ public class ParticleSystem {
 
 		mParticles = new ArrayList<Particle> ();
 		mTimeToLive = timeToLive;
-		
-		mParentLocation = new int[2];		
-		mParentView.getLocationInWindow(mParentLocation);
 		
 		DisplayMetrics displayMetrics = a.getResources().getDisplayMetrics();
 		mDpToPxScale = (displayMetrics.xdpi / DisplayMetrics.DENSITY_DEFAULT);
@@ -222,50 +222,132 @@ public class ParticleSystem {
 		return this;
 	}
 
+    /**
+     * Initializes the speed range and angle range of emitted particles. Angles are in degrees
+     * and non negative:
+     * 0 meaning to the right, 90 to the bottom,... in clockwise orientation. Speed is non
+	 * negative and is described in pixels per millisecond.
+     * @param speedMin The minimum speed to emit particles.
+     * @param speedMax The maximum speed to emit particles.
+     * @param minAngle The minimum angle to emit particles in degrees.
+     * @param maxAngle The maximum angle to emit particles in degrees.
+     * @return This.
+     */
 	public ParticleSystem setSpeedModuleAndAngleRange(float speedMin, float speedMax, int minAngle, int maxAngle) {
+        // else emitting from top (270°) to bottom (90°) range would not be possible if someone
+        // entered minAngle = 270 and maxAngle=90 since the module would swap the values
+        while (maxAngle < minAngle) {
+            maxAngle += 360;
+        }
 		mInitializers.add(new SpeeddModuleAndRangeInitializer(dpToPx(speedMin), dpToPx(speedMax), minAngle, maxAngle));		
 		return this;
 	}
 
+    /**
+     * Initializes the speed components ranges that particles will be emitted. Speeds are
+     * measured in density pixels per millisecond.
+     * @param speedMinX The minimum speed in x direction.
+     * @param speedMaxX The maximum speed in x direction.
+     * @param speedMinY The minimum speed in y direction.
+     * @param speedMaxY The maximum speed in y direction.
+     * @return This.
+     */
 	public ParticleSystem setSpeedByComponentsRange(float speedMinX, float speedMaxX, float speedMinY, float speedMaxY) {
-		mInitializers.add(new SpeeddByComponentsInitializer(dpToPx(speedMinX), dpToPx(speedMaxX), 
+        mInitializers.add(new SpeeddByComponentsInitializer(dpToPx(speedMinX), dpToPx(speedMaxX),
 				dpToPx(speedMinY), dpToPx(speedMaxY)));		
 		return this;
 	}
 
-	public ParticleSystem setInitialRotationRange (int minAngle, int maxAngle) {
+    /**
+     * Initializes the initial rotation range of emitted particles. The rotation angle is
+     * measured in degrees with 0° being no rotation at all and 90° tilting the image to the right.
+     * @param minAngle The minimum tilt angle.
+     * @param maxAngle The maximum tilt angle.
+     * @return This.
+     */
+	public ParticleSystem setInitialRotationRange(int minAngle, int maxAngle) {
 		mInitializers.add(new RotationInitiazer(minAngle, maxAngle));
 		return this;
 	}
 
+    /**
+     * Initializes the scale range of emitted particles. Will scale the images around their
+     * center multiplied with the given scaling factor.
+     * @param minScale The minimum scaling factor
+     * @param maxScale The maximum scaling factor.
+     * @return This.
+     */
 	public ParticleSystem setScaleRange(float minScale, float maxScale) {
 		mInitializers.add(new ScaleInitializer(minScale, maxScale));
 		return this;
 	}
 
+    /**
+     * Initializes the rotation speed of emitted particles. Rotation speed is measured in degrees
+     * per second.
+     * @param rotationSpeed The rotation speed.
+     * @return This.
+     */
 	public ParticleSystem setRotationSpeed(float rotationSpeed) {
-		mInitializers.add(new RotationSpeedInitializer(rotationSpeed, rotationSpeed));
+        mInitializers.add(new RotationSpeedInitializer(rotationSpeed, rotationSpeed));
 		return this;
 	}
 
+    /**
+     * Initializes the rotation speed range for emitted particles. The rotation speed is measured
+     * in degrees per second and can be positive or negative.
+     * @param minRotationSpeed The minimum rotation speed.
+     * @param maxRotationSpeed The maximum rotation speed.
+     * @return This.
+     */
 	public ParticleSystem setRotationSpeedRange(float minRotationSpeed, float maxRotationSpeed) {
-		mInitializers.add(new RotationSpeedInitializer(minRotationSpeed, maxRotationSpeed));
+        mInitializers.add(new RotationSpeedInitializer(minRotationSpeed, maxRotationSpeed));
 		return this;
 	}
 
+    /**
+     * Initializes the acceleration range and angle range of emitted particles. The acceleration
+     * components in x and y direction are controlled by the acceleration angle. The acceleration
+     * is measured in density pixels per square millisecond. The angle is measured in degrees
+     * with 0° pointing to the right and going clockwise.
+     * @param minAcceleration
+     * @param maxAcceleration
+     * @param minAngle
+     * @param maxAngle
+     * @return
+     */
 	public ParticleSystem setAccelerationModuleAndAndAngleRange(float minAcceleration, float maxAcceleration, int minAngle, int maxAngle) {
-		mInitializers.add(new AccelerationInitializer(dpToPx(minAcceleration), dpToPx(maxAcceleration), 
+        mInitializers.add(new AccelerationInitializer(dpToPx(minAcceleration), dpToPx(maxAcceleration),
 				minAngle, maxAngle));
 		return this;
 	}
 
+    /**
+     * Initializes the acceleration for emitted particles with the given angle. Acceleration is
+     * measured in pixels per square millisecond. The angle is measured in degrees with 0°
+     * meaning to the right and orientation being clockwise. The angle controls the acceleration
+     * direction.
+     * @param acceleration The acceleration.
+     * @param angle The acceleration direction.
+     * @return This.
+     */
 	public ParticleSystem setAcceleration(float acceleration, int angle) {
-		mInitializers.add(new AccelerationInitializer(acceleration, acceleration, angle, angle));
+        mInitializers.add(new AccelerationInitializer(acceleration, acceleration, angle, angle));
 		return this;
 	}
 
+    /**
+     * Initializes the parent view group. This needs to be done before any other configuration or
+     * emitting is done. Drawing will be done to a child that is added to this view. So this view
+     * needs to allow displaying an arbitrary sized view on top of its other content.
+     * @param viewGroup The view group to use.
+     * @return This.
+     */
 	public ParticleSystem setParentViewGroup(ViewGroup viewGroup) {
 		mParentView = viewGroup;
+        if (mParentView != null) {
+            mParentView.getLocationInWindow(mParentLocation);
+        }
 		return this;
 	}
 
@@ -277,7 +359,7 @@ public class ParticleSystem {
 	/**
 	 * Configures a fade out for the particles when they disappear
 	 * 
-	 * @param milisecondsBeforeEnd fade out duration in miliseconds
+	 * @param milisecondsBeforeEnd fade out duration in milliseconds
 	 * @param interpolator the interpolator for the fade out (default is linear)
 	 */
 	public ParticleSystem setFadeOut(long milisecondsBeforeEnd, Interpolator interpolator) {
@@ -288,7 +370,7 @@ public class ParticleSystem {
 	/**
 	 * Configures a fade out for the particles when they disappear
 	 * 
-	 * @param duration fade out duration in miliseconds
+	 * @param duration fade out duration in milliseconds
 	 */
 	public ParticleSystem setFadeOut(long duration) {
 		return setFadeOut(duration, new LinearInterpolator());

--- a/LeonidsLib/src/main/java/com/plattysoft/leonids/initializers/RotationInitiazer.java
+++ b/LeonidsLib/src/main/java/com/plattysoft/leonids/initializers/RotationInitiazer.java
@@ -16,7 +16,8 @@ public class RotationInitiazer implements ParticleInitializer {
 
 	@Override
 	public void initParticle(Particle p, Random r) {
-		int value = r.nextInt(mMaxAngle-mMinAngle)+mMinAngle;
+		int value = mMinAngle == mMaxAngle ? mMinAngle : r.nextInt(mMaxAngle-mMinAngle)
+				+mMinAngle;
 		p.mInitialRotation = value;
 	}
 


### PR DESCRIPTION
Fixed NPE when parent view cannot be found from activity (e.g. in DialogFragment). Setting parent manually now inits the position in window.
Added Javadoc for init methods with parameter explanation.
Fixed min=max initial rotation exception that happened with nextInt(0).