### PR TITLE
Adds constructor without activity requirement

### DIFF
--- a/LeonidsLib/src/main/java/com/plattysoft/leonids/ParticleSystem.java
+++ b/LeonidsLib/src/main/java/com/plattysoft/leonids/ParticleSystem.java
@@ -106,7 +106,36 @@ public class ParticleSystem {
 
 	/**
 	 * Creates a particle system with the given parameters
-	 * 
+	 *
+	 * @param parentView The parent view group
+	 * @param drawable The drawable to use as a particle
+	 * @param maxParticles The maximum number of particles
+	 * @param timeToLive The time to live for the particles
+	 */
+	public ParticleSystem(ViewGroup parentView, Drawable drawable, int maxParticles, long timeToLive) {
+		mRandom = new Random();
+		mParentLocation = new int[2];
+
+		setParentViewGroup(parentView);
+
+		mModifiers = new ArrayList<ParticleModifier>();
+		mInitializers = new ArrayList<ParticleInitializer>();
+
+		mMaxParticles = maxParticles;
+		// Create the particles
+
+		mParticles = new ArrayList<Particle> ();
+		mTimeToLive = timeToLive;
+
+		DisplayMetrics displayMetrics = parentView.getContext().getResources().getDisplayMetrics();
+		mDpToPxScale = (displayMetrics.xdpi / DisplayMetrics.DENSITY_DEFAULT);
+
+		createInitialParticles(drawable);
+	}
+
+	/**
+	 * Creates a particle system with the given parameters
+	 *
 	 * @param a The parent activity
 	 * @param maxParticles The maximum number of particles
 	 * @param drawableRedId The drawable resource to use as particle (supports Bitmaps and Animations)
@@ -151,6 +180,10 @@ public class ParticleSystem {
 	 */
 	public ParticleSystem(Activity a, int maxParticles, Drawable drawable, long timeToLive, int parentViewId) {
 		this(a, maxParticles, timeToLive, parentViewId);
+		createInitialParticles(drawable);
+	}
+
+	private void createInitialParticles(Drawable drawable) {
 		if (drawable instanceof BitmapDrawable) {
 			Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
 			for (int i=0; i<mMaxParticles; i++) {
@@ -164,7 +197,7 @@ public class ParticleSystem {
 			}
 		}
 //		else {
-			// Not supported, no particles are being created
+		// Not supported, no particles are being created
 //		}
 	}
 
@@ -498,6 +531,11 @@ public class ParticleSystem {
 	public void updateEmitPoint (int emitterX, int emitterY) {
 		configureEmiter(emitterX, emitterY);
 	}
+
+	public void updateEmitPoint (View emiter, int gravity) {
+		configureEmiter(emiter, gravity);
+	}
+
 	/**
 	 * Launches particles in one Shot
 	 * 

--- a/LeonidsLib/src/main/java/com/plattysoft/leonids/ParticleSystem.java
+++ b/LeonidsLib/src/main/java/com/plattysoft/leonids/ParticleSystem.java
@@ -84,35 +84,7 @@ public class ParticleSystem {
         }
     }
 
-    private ParticleSystem(Activity a, int maxParticles, long timeToLive, int parentResId) {
-		mRandom = new Random();
-        mParentLocation = new int[2];
-
-        mParentView = (ViewGroup) a.findViewById(parentResId);
-		setParentViewGroup(mParentView);
-
-		mModifiers = new ArrayList<ParticleModifier>();
-		mInitializers = new ArrayList<ParticleInitializer>();
-
-		mMaxParticles = maxParticles;
-		// Create the particles
-
-		mParticles = new ArrayList<Particle> ();
-		mTimeToLive = timeToLive;
-		
-		DisplayMetrics displayMetrics = a.getResources().getDisplayMetrics();
-		mDpToPxScale = (displayMetrics.xdpi / DisplayMetrics.DENSITY_DEFAULT);
-	}
-
-	/**
-	 * Creates a particle system with the given parameters
-	 *
-	 * @param parentView The parent view group
-	 * @param drawable The drawable to use as a particle
-	 * @param maxParticles The maximum number of particles
-	 * @param timeToLive The time to live for the particles
-	 */
-	public ParticleSystem(ViewGroup parentView, Drawable drawable, int maxParticles, long timeToLive) {
+	private ParticleSystem(ViewGroup parentView, int maxParticles, long timeToLive) {
 		mRandom = new Random();
 		mParentLocation = new int[2];
 
@@ -129,8 +101,34 @@ public class ParticleSystem {
 
 		DisplayMetrics displayMetrics = parentView.getContext().getResources().getDisplayMetrics();
 		mDpToPxScale = (displayMetrics.xdpi / DisplayMetrics.DENSITY_DEFAULT);
+	}
 
-		createInitialParticles(drawable);
+	/**
+	 * Creates a particle system with the given parameters
+	 *
+	 * @param parentView The parent view group
+	 * @param drawable The drawable to use as a particle
+	 * @param maxParticles The maximum number of particles
+	 * @param timeToLive The time to live for the particles
+	 */
+	public ParticleSystem(ViewGroup parentView, int maxParticles, Drawable drawable, long timeToLive) {
+		this(parentView, maxParticles, timeToLive);
+
+		if (drawable instanceof BitmapDrawable) {
+			Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
+			for (int i=0; i<mMaxParticles; i++) {
+				mParticles.add (new Particle (bitmap));
+			}
+		}
+		else if (drawable instanceof AnimationDrawable) {
+			AnimationDrawable animation = (AnimationDrawable) drawable;
+			for (int i=0; i<mMaxParticles; i++) {
+				mParticles.add (new AnimatedParticle (animation));
+			}
+		}
+//		else {
+		// Not supported, no particles are being created
+//		}
 	}
 
 	/**
@@ -179,26 +177,7 @@ public class ParticleSystem {
      * @param parentViewId The view Id for the parent of the particle system
 	 */
 	public ParticleSystem(Activity a, int maxParticles, Drawable drawable, long timeToLive, int parentViewId) {
-		this(a, maxParticles, timeToLive, parentViewId);
-		createInitialParticles(drawable);
-	}
-
-	private void createInitialParticles(Drawable drawable) {
-		if (drawable instanceof BitmapDrawable) {
-			Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
-			for (int i=0; i<mMaxParticles; i++) {
-				mParticles.add (new Particle (bitmap));
-			}
-		}
-		else if (drawable instanceof AnimationDrawable) {
-			AnimationDrawable animation = (AnimationDrawable) drawable;
-			for (int i=0; i<mMaxParticles; i++) {
-				mParticles.add (new AnimatedParticle (animation));
-			}
-		}
-//		else {
-		// Not supported, no particles are being created
-//		}
+		this((ViewGroup) a.findViewById(parentViewId), maxParticles, drawable, timeToLive);
 	}
 
 	public float dpToPx(float dp) {
@@ -226,7 +205,7 @@ public class ParticleSystem {
      * @param parentViewId The view Id for the parent of the particle system
 	 */
 	public ParticleSystem(Activity a, int maxParticles, Bitmap bitmap, long timeToLive, int parentViewId) {
-		this(a, maxParticles, timeToLive, parentViewId);
+		this((ViewGroup) a.findViewById(parentViewId), maxParticles, timeToLive);
 		for (int i=0; i<mMaxParticles; i++) {
 			mParticles.add (new Particle (bitmap));
 		}
@@ -254,7 +233,7 @@ public class ParticleSystem {
      * @param parentViewId The view Id for the parent of the particle system
 	 */
 	public ParticleSystem(Activity a, int maxParticles, AnimationDrawable animation, long timeToLive, int parentViewId) {
-		this(a, maxParticles, timeToLive, parentViewId);
+		this((ViewGroup) a.findViewById(parentViewId), maxParticles, timeToLive);
 		// Create the particles
 		for (int i=0; i<mMaxParticles; i++) {
 			mParticles.add (new AnimatedParticle (animation));

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ There are also constructors that recieve a view id to use as the parent so you c
 * _ParticleSystem(Activity a, int maxParticles, Bitmap bitmap, long timeToLive, int parentViewId)_
 * _ParticleSystem(Activity a, int maxParticles, AnimationDrawable animation, long timeToLive, int parentViewId)_
 
+And another constructor that receives a parent viewgroup and drawable for use in places where it is not practical to pass a reference to an Activity
+
+* _ParticleSystem(ViewGroup parentView, Drawable drawable, int maxParticles, long timeToLive)_
+
 ### Configuration
 
 Available methods on the Particle system for configuration are:
@@ -159,6 +163,7 @@ Emits the number of particles per second from the emitter. If emittingTime is se
  
 ####Update, stop, and cancel
 * _updateEmitPoint (int emitterX, int emitterY)_ Updates dynamically the point of emission.
+* _updateEmitPoint (View emiter, int gravity)_ Updates dynamically the point of emission using gravity.
 * _stopEmitting ()_ Stops the emission of new particles, but the active ones are updated.
 * _cancel ()_ Stops the emission of new particles and cancles the active ones.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ There are also constructors that recieve a view id to use as the parent so you c
 
 And another constructor that receives a parent viewgroup and drawable for use in places where it is not practical to pass a reference to an Activity
 
-* _ParticleSystem(ViewGroup parentView, Drawable drawable, int maxParticles, long timeToLive)_
+* _ParticleSystem(ViewGroup parentView, int maxParticles, Drawable drawable, long timeToLive)_
 
 ### Configuration
 


### PR DESCRIPTION
This should address issue #48 and also partially #50. The new constructor method signature is

`public ParticleSystem(ViewGroup parentView, Drawable drawable, int maxParticles, long timeToLive)`

I've also added a utility method for updating the emitter position but using a view and gravity instead of just the existing method with x and y coords.