### PR TITLE
Add ability to add a custom initializer.

### DIFF
--- a/LeonidsLib/src/main/java/com/plattysoft/leonids/ParticleSystem.java
+++ b/LeonidsLib/src/main/java/com/plattysoft/leonids/ParticleSystem.java
@@ -363,6 +363,19 @@ public class ParticleSystem {
 		return this;
 	}
 
+	/**
+	 * Adds a custom initializer for emitted particles. The most common use case is the ability to
+	 * update the initializer in real-time instead of adding new ones ontop of the existing one.
+	 * @param initializer The non-null initializer to add.
+	 * @return This.
+	 */
+	public ParticleSystem addInitializer(ParticleInitializer initializer) {
+		if (initializer != null) {
+			mInitializers.add(initializer);
+		}
+		return this;
+	}
+
     /**
      * Initializes the acceleration for emitted particles with the given angle. Acceleration is
      * measured in pixels per square millisecond. The angle is measured in degrees with 0°


### PR DESCRIPTION
This is needed in cases where a particle system's
initializer needs to be updated on the fly (such as from
a sensor listener). Prior to this a new ParticleSystem
would have to be created or extra initializers would have
to be added. Since the extra initializers simply override
the previous initialization, they bloat memory.

Fixes #75