### PR TITLE
Extract emitter shape so it no longer depens on a View.

### DIFF
--- a/LeonidsLib/src/main/java/com/plattysoft/leonids/ParticleSystem.java
+++ b/LeonidsLib/src/main/java/com/plattysoft/leonids/ParticleSystem.java
@@ -17,6 +17,8 @@ import android.view.ViewGroup;
 import android.view.animation.Interpolator;
 import android.view.animation.LinearInterpolator;
 
+import com.plattysoft.leonids.emitters.Emitter;
+import com.plattysoft.leonids.emitters.ViewEmitter;
 import com.plattysoft.leonids.initializers.AccelerationInitializer;
 import com.plattysoft.leonids.initializers.ParticleInitializer;
 import com.plattysoft.leonids.initializers.RotationInitializer;
@@ -439,6 +441,13 @@ public class ParticleSystem {
 	}
 
 	/**
+	 * @see #emitWithGravity(View, int, int, int)
+	 */
+	public void emitWithGravity (View emitter, int gravity, int particlesPerSecond, int emittingTime) {
+		emitWithGravity(new ViewEmitter(emitter), gravity, particlesPerSecond, emittingTime);
+	}
+
+	/**
 	 * Starts emitting particles from a specific view. If at some point the number goes over the amount of particles availabe on create
 	 * no new particles will be created
 	 *
@@ -447,7 +456,7 @@ public class ParticleSystem {
 	 * @param particlesPerSecond Number of particles per second that will be emited (evenly distributed)
 	 * @param emittingTime time the emitter will be emitting particles
 	 */
-	public void emitWithGravity (View emitter, int gravity, int particlesPerSecond, int emittingTime) {
+	public void emitWithGravity (Emitter emitter, int gravity, int particlesPerSecond, int emittingTime) {
 		// Setup emitter
 		configureEmitter(emitter, gravity);
 		startEmitting(particlesPerSecond, emittingTime);
@@ -487,7 +496,7 @@ public class ParticleSystem {
 	 */
 	public void emitWithGravity (View emitter, int gravity, int particlesPerSecond) {
 		// Setup emitter
-		configureEmitter(emitter, gravity);
+		configureEmitter(new ViewEmitter(emitter), gravity);
 		startEmitting(particlesPerSecond);
 	}
 
@@ -541,7 +550,18 @@ public class ParticleSystem {
 	}
 
 	public void updateEmitPoint (View emitter, int gravity) {
+		updateEmitPoint(new ViewEmitter(emitter), gravity);
+	}
+
+	public void updateEmitPoint (Emitter emitter, int gravity) {
 		configureEmitter(emitter, gravity);
+	}
+
+	/**
+	 * @see #oneShot(Emitter, int)
+	 */
+	public void oneShot(View emitter, int numParticles) {
+		oneShot(new ViewEmitter(emitter), numParticles);
 	}
 
 	/**
@@ -550,8 +570,15 @@ public class ParticleSystem {
 	 * @param emitter View from which center the particles will be emited
 	 * @param numParticles number of particles launched on the one shot
 	 */
-	public void oneShot(View emitter, int numParticles) {
+	public void oneShot(Emitter emitter, int numParticles) {
 		oneShot(emitter, numParticles, new LinearInterpolator());
+	}
+
+	/**
+	 * @see #oneShot(Emitter, int, Interpolator)
+	 */
+	public void oneShot(View emitter, int numParticles, Interpolator interpolator) {
+		oneShot(new ViewEmitter(emitter), numParticles, interpolator);
 	}
 
 	/**
@@ -561,7 +588,7 @@ public class ParticleSystem {
 	 * @param numParticles number of particles launched on the one shot
 	 * @param interpolator the interpolator for the time
 	 */
-	public void oneShot(View emitter, int numParticles, Interpolator interpolator) {
+	public void oneShot(Emitter emitter, int numParticles, Interpolator interpolator) {
 		configureEmitter(emitter, Gravity.CENTER);
 		mActivatedParticles = 0;
 		mEmittingTime = mTimeToLive;
@@ -609,47 +636,44 @@ public class ParticleSystem {
 		mAnimator.start();
 	}
 
-	private void configureEmitter(View emitter, int gravity) {
-		// It works with an emision range
-		int[] location = new int[2];
-		emitter.getLocationInWindow(location);
+	private void configureEmitter(Emitter emitter, int gravity) {
 
 		// Check horizontal gravity and set range
 		if (hasGravity(gravity, Gravity.LEFT)) {
-			mEmitterXMin = location[0] - mParentLocation[0];
+			mEmitterXMin = emitter.getX() - mParentLocation[0];
 			mEmitterXMax = mEmitterXMin;
 		}
 		else if (hasGravity(gravity, Gravity.RIGHT)) {
-			mEmitterXMin = location[0] + emitter.getWidth() - mParentLocation[0];
+			mEmitterXMin = emitter.getX() + emitter.getWidth() - mParentLocation[0];
 			mEmitterXMax = mEmitterXMin;
 		}
 		else if (hasGravity(gravity, Gravity.CENTER_HORIZONTAL)){
-			mEmitterXMin = location[0] + emitter.getWidth()/2 - mParentLocation[0];
+			mEmitterXMin = emitter.getX() + emitter.getWidth()/2 - mParentLocation[0];
 			mEmitterXMax = mEmitterXMin;
 		}
 		else {
 			// All the range
-			mEmitterXMin = location[0] - mParentLocation[0];
-			mEmitterXMax = location[0] + emitter.getWidth() - mParentLocation[0];
+			mEmitterXMin = emitter.getX() - mParentLocation[0];
+			mEmitterXMax = emitter.getX() + emitter.getWidth() - mParentLocation[0];
 		}
 
 		// Now, vertical gravity and range
 		if (hasGravity(gravity, Gravity.TOP)) {
-			mEmitterYMin = location[1] - mParentLocation[1];
+			mEmitterYMin = emitter.getY() - mParentLocation[1];
 			mEmitterYMax = mEmitterYMin;
 		}
 		else if (hasGravity(gravity, Gravity.BOTTOM)) {
-			mEmitterYMin = location[1] + emitter.getHeight() - mParentLocation[1];
+			mEmitterYMin = emitter.getY() + emitter.getHeight() - mParentLocation[1];
 			mEmitterYMax = mEmitterYMin;
 		}
 		else if (hasGravity(gravity, Gravity.CENTER_VERTICAL)){
-			mEmitterYMin = location[1] + emitter.getHeight()/2 - mParentLocation[1];
+			mEmitterYMin = emitter.getY() + emitter.getHeight()/2 - mParentLocation[1];
 			mEmitterYMax = mEmitterYMin;
 		}
 		else {
 			// All the range
-			mEmitterYMin = location[1] - mParentLocation[1];
-			mEmitterYMax = location[1] + emitter.getHeight() - mParentLocation[1];
+			mEmitterYMin = emitter.getY() - mParentLocation[1];
+			mEmitterYMax = emitter.getY() + emitter.getHeight() - mParentLocation[1];
 		}
 	}
 

--- a/LeonidsLib/src/main/java/com/plattysoft/leonids/emitters/Emitter.java
+++ b/LeonidsLib/src/main/java/com/plattysoft/leonids/emitters/Emitter.java
@@ -1,0 +1,11 @@
+package com.plattysoft.leonids.emitters;
+
+/**
+ * Specifies an area with which particles should be emitted from.
+ */
+public interface Emitter {
+    int getX();
+    int getY();
+    int getWidth();
+    int getHeight();
+}

--- a/LeonidsLib/src/main/java/com/plattysoft/leonids/emitters/RectEmitter.java
+++ b/LeonidsLib/src/main/java/com/plattysoft/leonids/emitters/RectEmitter.java
@@ -1,0 +1,42 @@
+package com.plattysoft.leonids.emitters;
+
+/**
+ * Specifies an arbitrary rectangular area where particles can be emitted from.
+ * This will be relative to whatever parent view the emitter is attached to. So for example, if
+ * you specify an "x" of 10px for this rectangle, and the parent view is offset 100px from the
+ * edge of the screen, then the total offset will be 110px from the edge of the screen.
+ */
+public class RectEmitter implements Emitter {
+
+    private final int x;
+    private final int y;
+    private final int width;
+    private final int height;
+
+    public RectEmitter(int x, int y, int width, int height) {
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+    }
+
+    @Override
+    public int getX() {
+        return x;
+    }
+
+    @Override
+    public int getY() {
+        return y;
+    }
+
+    @Override
+    public int getWidth() {
+        return width;
+    }
+
+    @Override
+    public int getHeight() {
+        return height;
+    }
+}

--- a/LeonidsLib/src/main/java/com/plattysoft/leonids/emitters/ViewEmitter.java
+++ b/LeonidsLib/src/main/java/com/plattysoft/leonids/emitters/ViewEmitter.java
@@ -1,0 +1,45 @@
+package com.plattysoft.leonids.emitters;
+
+import android.view.View;
+
+/**
+ * Emit particles within the area occupied by a particular {@link View}.
+ */
+public class ViewEmitter implements Emitter {
+
+    private final int x;
+    private final int y;
+    private final int width;
+    private final int height;
+
+    public ViewEmitter(final View view) {
+        // It works with an emission range
+        int[] location = new int[2];
+        view.getLocationInWindow(location);
+
+        x = location[0];
+        y = location[1];
+        width = view.getWidth();
+        height = view.getHeight();
+    }
+
+    @Override
+    public int getX() {
+        return x;
+    }
+
+    @Override
+    public int getY() {
+        return y;
+    }
+
+    @Override
+    public int getWidth() {
+        return width;
+    }
+
+    @Override
+    public int getHeight() {
+        return height;
+    }
+}


### PR DESCRIPTION
Now, the interface just specifies x, y, width and height. This allows for either
a Android `View` object, or alternatively an arbitrary rectangle to be used for emission
locations.

It maintains backward compatibility with the current API by overloading each method which accepts a `View`. The new method accepts an `Emitter`, and the old method delegates to the new method, by passing in a `new ViewEmitter(view)` whenever the new method expects an `Emitter`. 

In the future, this could be further refactored to expose even more flexibility. For example, the entire calculation for initial particle locations into the new `Emitter` interface. That is to say, instead of it being hard coded to use `x`, `y`, `width`, `height` (and hence a rectangle emission area), we could instead have an interface which exposes a method `generateParticleLocation()`. Some emitters may choose to use a rect, others could use a circle. Others could do even more interesting things such as from a point, but randomly distributed around the point according to a Gaussian distribution.

Another future refactoring would be to attach the `gravity` argument to the `Emitter` itself. That way the `ParticleSystem` itself doesn't need to care about whether to anchor particles to the top or bottom of a rectangle area. Instead you would configure this on the emitter object before passing it to the particle system.